### PR TITLE
ci(release): configure npm to publish scoped package publicly

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "repository": "github:pcattori/react-toolkit",
   "license": "MIT",
   "author": "Pedro Cattori <pcattori@gmail.com>",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "src/index.js",
   "scripts": {
     "format": "prettier --check .",


### PR DESCRIPTION
see https://docs.npmjs.com/creating-and-publishing-scoped-public-packages