### PR TITLE
ci(release): only include README (implicitly) and src/ directory (exp…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "repository": "github:pcattori/react-toolkit",
   "license": "MIT",
   "author": "Pedro Cattori <pcattori@gmail.com>",
+  "files": [
+    "src/**/*"
+  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
…licitly) in published tarball